### PR TITLE
A few changes

### DIFF
--- a/SCPageScrubberBar/SCCalloutView.m
+++ b/SCPageScrubberBar/SCCalloutView.m
@@ -33,6 +33,16 @@
 
 @implementation SCCalloutView
 
+
+@synthesize anchorDirection = _anchorDirection;
+@synthesize titleLabel = _titleLabel;
+@synthesize subtitleLabel = _subtitleLabel;
+@synthesize titleLabelInsets = _titleLabelInsets;
+@synthesize subtitleLabelInsets = _subtitleLabelInsets;
+@synthesize maxWidth = _maxWidth;
+@synthesize minWidth = _minWidth;
+
+
 - (id)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];

--- a/SCPageScrubberBar/SCCalloutView.m
+++ b/SCPageScrubberBar/SCCalloutView.m
@@ -7,6 +7,8 @@
 //
 
 #import "SCCalloutView.h"
+#import "NSString+BZExtensions.h"   // Hsoi 2013-08-19 - not ideal to use our own, but here we are.
+
 #define kSCCalloutViewHeight 43.0f
 #define kSCCalloutViewMinWidth 20.0f
 #define kSCCalloutViewMinWidthWidthAnthor 41.0f
@@ -73,8 +75,8 @@
 
 - (CGSize)sizeThatFits:(CGSize)size
 {
-    CGSize titleLabelSize = [self.titleLabel.text sizeWithFont:self.titleLabel.font];
-    CGSize subTitleLabelSize = [self.subtitleLabel.text sizeWithFont:self.subtitleLabel.font];
+    CGSize titleLabelSize = [self.titleLabel.text barz_sizeWithFont:self.titleLabel.font];
+    CGSize subTitleLabelSize = [self.subtitleLabel.text barz_sizeWithFont:self.subtitleLabel.font];
     // Get the max width of the two labels
     CGFloat maxLabelsWidth = MAX(titleLabelSize.width, subTitleLabelSize.width);
     
@@ -184,11 +186,7 @@
         _titleLabel.shadowColor = [UIColor blackColor];
         _titleLabel.shadowOffset = CGSizeMake(0, -1);
         _titleLabel.contentMode = UIViewContentModeCenter;
-        if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 6.0) {
-            _titleLabel.textAlignment = NSTextAlignmentCenter;
-        } else {
-            _titleLabel.textAlignment = UITextAlignmentCenter;
-        }
+        _titleLabel.textAlignment = NSTextAlignmentCenter;
     }
     return _titleLabel;
 }
@@ -203,11 +201,7 @@
         _subtitleLabel.shadowColor = [UIColor blackColor];
         _subtitleLabel.shadowOffset = CGSizeMake(0, -1);
         _subtitleLabel.contentMode = UIViewContentModeCenter;
-        if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 6.0) {
-            _subtitleLabel.textAlignment = NSTextAlignmentCenter;
-        } else {
-            _subtitleLabel.textAlignment = UITextAlignmentCenter;
-        }
+        _subtitleLabel.textAlignment = NSTextAlignmentCenter;
     }
     return _subtitleLabel;
 }

--- a/SCPageScrubberBar/SCPageScrubberBar.h
+++ b/SCPageScrubberBar/SCPageScrubberBar.h
@@ -13,6 +13,9 @@
 @property (nonatomic, weak) id <SCPageScrubberBarDelegate> delegate;
 @property (nonatomic, assign) BOOL alwaysShowTitleView;
 @property (nonatomic, assign) BOOL isPopoverMode;
+
+- (void)setValue:(float)value showCallout:(BOOL)show;
+
 @end
 
 @protocol SCPageScrubberBarDelegate <NSObject>

--- a/SCPageScrubberBar/SCPageScrubberBar.m
+++ b/SCPageScrubberBar/SCPageScrubberBar.m
@@ -21,7 +21,6 @@
 - (void)_fadeCalloutViewInAndOut:(BOOL)aFadeIn;
 - (void)_updateCalloutViewPosition;
 - (void)_updateCalloutViewText;
-- (UIImage*)_generateDotsImage;
 @end
 
 @implementation SCPageScrubberBar
@@ -64,6 +63,23 @@
     [self _updateCalloutViewPosition];
 }
 
+- (void)setValue:(float)value showCallout:(BOOL)show {
+    self.value = value;
+    
+    if (show) {
+        self.calloutView.alpha = 0.0;
+        [UIView animateWithDuration:0.5
+                         animations:^{
+                             self.calloutView.alpha = 1.0;
+                         } completion:^(BOOL finished) {
+                             [UIView animateWithDuration:0.5
+                                              animations:^{
+                                                  self.calloutView.alpha = 0.0;
+                                              } completion:NULL];
+                         }];
+    }
+}
+
 #pragma mark - Self Private Methods
 
 - (CGRect)_thumbRect
@@ -77,14 +93,15 @@
 
 - (void)_fadeCalloutViewInAndOut:(BOOL)aFadeIn
 {
-    [UIView beginAnimations:nil context:NULL];
-    [UIView setAnimationDuration:0.5];
-    if (aFadeIn) {
-        self.calloutView.alpha = 1.0;
-    } else {
-        self.calloutView.alpha = 0.0;
-    }
-    [UIView commitAnimations];
+    [UIView animateWithDuration:0.5
+                     animations:^{
+                         if (aFadeIn) {
+                             self.calloutView.alpha = 1.0;
+                         }
+                         else {
+                             self.calloutView.alpha = 0.0;
+                         }
+                     } completion:NULL];    
 }
 
 - (void)_updateCalloutViewPosition
@@ -116,31 +133,6 @@
     }
     
     [self.calloutView sizeToFit];
-}
-
-- (UIImage*)_generateDotsImage
-{
-    // Get the image of one dot
-    UIImage *image = [UIImage imageNamed:@"SCPageScrubberBar.bundle/dot.png"];
-    CGFloat scale = [UIScreen mainScreen].scale;
-    CGSize size = CGSizeMake(self.bounds.size.width, image.size.height);
-    // The total width of one dot including spacing
-    CGFloat oneDotWidth = image.size.width + kSCDotImageSpacing;
-    
-    UIGraphicsBeginImageContextWithOptions(size, NO, scale);
-    CGContextRef ctx = UIGraphicsGetCurrentContext();
-    
-    // Draw dotImage repeatly
-    NSInteger len = (int)(size.width / oneDotWidth);
-    for (NSInteger i = 0; i < len; i++) {
-        CGPoint drawPoint = CGPointMake(i * oneDotWidth + kSCDotImageSpacing / 2, 0);
-        CGContextDrawImage(ctx, (CGRect){drawPoint, image.size}, image.CGImage);
-    }
-    
-    // Generate the image
-    UIImage *resultImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    return resultImage;
 }
 
 
@@ -220,8 +212,8 @@
 - (SCCalloutView *)calloutView
 {
     if (_calloutView == nil) {
-        _calloutView = [[SCCalloutView alloc] initWithFrame:CGRectMake(0, 0, 100, 0)];
-        _calloutView.alpha = 0;
+        _calloutView = [[SCCalloutView alloc] initWithFrame:CGRectMake(0.0, 0.0, 100.0, 0.0)];
+        _calloutView.alpha = 0.0;
         _calloutView.anchorDirection = self.isPopoverMode ? SCCalloutViewAnchorBottom : SCCalloutViewAnchorNone;
     }
     return _calloutView;
@@ -232,9 +224,9 @@
     if (_alwaysShowTitleView != alwaysShowTitleView) {
         _alwaysShowTitleView = alwaysShowTitleView;
         if (_alwaysShowTitleView) {
-            self.calloutView.alpha = 1;
+            self.calloutView.alpha = 1.0;
         } else {
-            self.calloutView.alpha = 0;
+            self.calloutView.alpha = 0.0;
         }
     }
 }

--- a/SCPageScrubberBar/SCPageScrubberBar.m
+++ b/SCPageScrubberBar/SCPageScrubberBar.m
@@ -57,6 +57,9 @@
     nFrame.size.width = self.bounds.size.width;
     self.backgroundLayer.frame = nFrame;
     
+    _dotsImage = nil;
+    self.backgroundLayer.contents = (id)self.dotsImage.CGImage;
+    
     [self _updateCalloutViewText];
     [self _updateCalloutViewPosition];
 }

--- a/SCPageScrubberBar/SCPageScrubberBar.m
+++ b/SCPageScrubberBar/SCPageScrubberBar.m
@@ -26,6 +26,14 @@
 
 @implementation SCPageScrubberBar
 
+@synthesize dotsImage = _dotsImage;
+@synthesize clearImage = _clearImage;
+@synthesize backgroundLayer = _backgroundLayer;
+@synthesize calloutView = _calloutView;
+@synthesize delegate = _delegate;
+@synthesize alwaysShowTitleView = _alwaysShowTitleView;
+@synthesize isPopoverMode = _isPopoverMode;
+
 - (id)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];

--- a/SCPageScrubberBar/SCPageScrubberBar.m
+++ b/SCPageScrubberBar/SCPageScrubberBar.m
@@ -39,10 +39,15 @@
     if (self) {
         // Initialization code
         [self.layer addSublayer:self.backgroundLayer];
-        UIImage* thumbImage = [UIImage imageNamed:@"SCPageScrubberBar.bundle/thumb.png"];
+        
+        // Hsoi 2013-09-19 - as a quick way of having a more iOS7 look and feel, only use the
+        // bundled thumb image under pre-7 OS's. Otherwise, just use the 7 slider thumb.
+        if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1) {
+            UIImage* thumbImage = [UIImage imageNamed:@"SCPageScrubberBar.bundle/thumb.png"];
+            [self setThumbImage:thumbImage forState:UIControlStateNormal];
+        }
         [self setMaximumTrackImage:self.clearImage forState:UIControlStateNormal];
         [self setMinimumTrackImage:self.clearImage forState:UIControlStateNormal];
-        [self setThumbImage:thumbImage forState:UIControlStateNormal];
 
         [self addSubview:self.calloutView];
     }


### PR DESCRIPTION
The main change that would be useful to pull would be from commit:

https://github.com/barz/SCPageScrubberBar/commit/56f87444186a5dca45db24b3a956756b18d6bd75

to fix a redraw problem when the device rotation changes. In my case, the scrubber was at the bottom of a portrait view, but when the device went landscape while the bar still worked the dots didn't redraw and so it looked weird.

The other changes are up to you to pull. I don't know if it was important for you to maintain old OS version support, but otherwise it's now preferred to adopt the block-based animations.  I added the one method to "flash" the callout for the particular use-case I had.
